### PR TITLE
Fix: 하단 사항들 수정

### DIFF
--- a/app/src/main/java/com/sooum/android/data/remote/AppVersion.kt
+++ b/app/src/main/java/com/sooum/android/data/remote/AppVersion.kt
@@ -1,0 +1,10 @@
+package com.sooum.android.data.remote
+
+
+import retrofit2.http.GET
+
+interface AppVersionApi {
+    @GET("/app/version/android")
+    suspend fun getAppVersion(
+    ): String
+}

--- a/app/src/main/java/com/sooum/android/data/remote/AppVersion.kt
+++ b/app/src/main/java/com/sooum/android/data/remote/AppVersion.kt
@@ -1,10 +1,11 @@
 package com.sooum.android.data.remote
 
 
+import okhttp3.ResponseBody
 import retrofit2.http.GET
 
 interface AppVersionApi {
     @GET("/app/version/android")
     suspend fun getAppVersion(
-    ): String
+    ): ResponseBody
 }

--- a/app/src/main/java/com/sooum/android/data/repository/AppVersionRepositoryImpl.kt
+++ b/app/src/main/java/com/sooum/android/data/repository/AppVersionRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package com.sooum.android.data.repository
+
+import com.sooum.android.data.remote.AppVersionApi
+import com.sooum.android.domain.repository.AppVersionRepository
+import javax.inject.Inject
+
+class AppVersionRepositoryImpl @Inject constructor(
+    private val appVersionApi: AppVersionApi
+):AppVersionRepository {
+    override suspend fun getAppVersion(): String {
+        return appVersionApi.getAppVersion()
+    }
+}

--- a/app/src/main/java/com/sooum/android/data/repository/AppVersionRepositoryImpl.kt
+++ b/app/src/main/java/com/sooum/android/data/repository/AppVersionRepositoryImpl.kt
@@ -8,6 +8,7 @@ class AppVersionRepositoryImpl @Inject constructor(
     private val appVersionApi: AppVersionApi
 ):AppVersionRepository {
     override suspend fun getAppVersion(): String {
-        return appVersionApi.getAppVersion()
+        val responseBody = appVersionApi.getAppVersion()
+        return responseBody.string()
     }
 }

--- a/app/src/main/java/com/sooum/android/di/NetworkModule.kt
+++ b/app/src/main/java/com/sooum/android/di/NetworkModule.kt
@@ -16,7 +16,6 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import retrofit2.converter.scalars.ScalarsConverterFactory
 import javax.inject.Singleton
 
 @Module
@@ -37,7 +36,6 @@ object NetworkModule {
             .Builder()
             .baseUrl(BASE_URL)
             .client(client)
-            .addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }

--- a/app/src/main/java/com/sooum/android/di/NetworkModule.kt
+++ b/app/src/main/java/com/sooum/android/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.sooum.android.di
 
 import com.sooum.android.Constants.BASE_URL
+import com.sooum.android.data.remote.AppVersionApi
 import com.sooum.android.data.remote.AuthInterceptor
 import com.sooum.android.data.remote.CardApi
 import com.sooum.android.data.remote.NotificationApi
@@ -15,6 +16,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.converter.scalars.ScalarsConverterFactory
 import javax.inject.Singleton
 
 @Module
@@ -35,6 +37,7 @@ object NetworkModule {
             .Builder()
             .baseUrl(BASE_URL)
             .client(client)
+            .addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }
@@ -67,5 +70,11 @@ object NetworkModule {
     @Provides
     fun getNotificationApiInstance(retrofit: Retrofit) : NotificationApi {
         return retrofit.create(NotificationApi::class.java)
+    }
+
+    @Singleton
+    @Provides
+    fun getAppVersionApiInstance(retrofit: Retrofit) : AppVersionApi {
+        return retrofit.create(AppVersionApi::class.java)
     }
 }

--- a/app/src/main/java/com/sooum/android/di/RepositoryModule.kt
+++ b/app/src/main/java/com/sooum/android/di/RepositoryModule.kt
@@ -1,11 +1,13 @@
 package com.sooum.android.di
 
+import com.sooum.android.data.repository.AppVersionRepositoryImpl
 import com.sooum.android.data.repository.PostCardRepositoryImpl
 import com.sooum.android.data.repository.HomeFeedRepositoryImpl
 import com.sooum.android.data.repository.DetailRepositoryImpl
 import com.sooum.android.data.repository.MyProfileRepositoryImpl
 import com.sooum.android.data.repository.NotificationRepositoryImpl
 import com.sooum.android.data.repository.TagRepositoryImpl
+import com.sooum.android.domain.repository.AppVersionRepository
 import com.sooum.android.domain.repository.PostCardRepository
 import com.sooum.android.domain.repository.HomeFeedRepository
 import com.sooum.android.domain.repository.DetailRepository
@@ -45,4 +47,8 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun notificationRepository(notificationRepositoryImpl: NotificationRepositoryImpl) : NotificationRepository
+
+    @Singleton
+    @Binds
+    abstract fun appVersionRepositoryRepository(appVersionRepositoryImpl: AppVersionRepositoryImpl) : AppVersionRepository
 }

--- a/app/src/main/java/com/sooum/android/domain/repository/AppVersionRepository.kt
+++ b/app/src/main/java/com/sooum/android/domain/repository/AppVersionRepository.kt
@@ -1,0 +1,5 @@
+package com.sooum.android.domain.repository
+
+interface AppVersionRepository {
+    suspend fun getAppVersion():String
+}

--- a/app/src/main/java/com/sooum/android/domain/usecase/version/AppVersionUseCase.kt
+++ b/app/src/main/java/com/sooum/android/domain/usecase/version/AppVersionUseCase.kt
@@ -1,0 +1,12 @@
+package com.sooum.android.domain.usecase.version
+
+import com.sooum.android.domain.repository.AppVersionRepository
+import javax.inject.Inject
+
+class AppVersionUseCase @Inject constructor(
+    private val repository : AppVersionRepository
+) {
+    suspend operator fun invoke():String {
+        return repository.getAppVersion()
+    }
+}

--- a/app/src/main/java/com/sooum/android/ui/AddPostScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/AddPostScreen.kt
@@ -64,7 +64,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -85,7 +84,6 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.zIndex
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -1215,6 +1213,15 @@ fun ContentCard(
             ) {
                 if (imgType == ImgTypeEnum.DEFAULT) ImageLoaderForUrl(selectedImageForDefault)
                 else ImageLoaderForBitmap(selectedImageForGallery)
+                if(imgType == ImgTypeEnum.DEFAULT) {
+                    ImageLoaderForUrl(selectedImageForDefault)
+                }else {
+                    if(selectedImageForGallery == null) {
+                        ImageLoaderForUrl(selectedImageForDefault)
+                    }else {
+                        ImageLoaderForBitmap(selectedImageForGallery)
+                    }
+                }
             }
             Box(
                 modifier = Modifier

--- a/app/src/main/java/com/sooum/android/ui/AddPostScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/AddPostScreen.kt
@@ -1213,15 +1213,6 @@ fun ContentCard(
             ) {
                 if (imgType == ImgTypeEnum.DEFAULT) ImageLoaderForUrl(selectedImageForDefault)
                 else ImageLoaderForBitmap(selectedImageForGallery)
-                if(imgType == ImgTypeEnum.DEFAULT) {
-                    ImageLoaderForUrl(selectedImageForDefault)
-                }else {
-                    if(selectedImageForGallery == null) {
-                        ImageLoaderForUrl(selectedImageForDefault)
-                    }else {
-                        ImageLoaderForBitmap(selectedImageForGallery)
-                    }
-                }
             }
             Box(
                 modifier = Modifier

--- a/app/src/main/java/com/sooum/android/ui/HomeScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/HomeScreen.kt
@@ -443,168 +443,220 @@ fun DistanceFeedList(
     distance: DistanceEnum,
 ) {
     val coroutineScope = rememberCoroutineScope()
-    Log.e("asd","거리 값 $distance")
 
     var isRefreshing by remember { mutableStateOf(false) }
 
-    val lazyDistance1Feed = homeViewModel.lazyDistance1Feed.collectAsLazyPagingItems()
-    val lazyDistance5Feed = homeViewModel.lazyDistance5Feed.collectAsLazyPagingItems()
-    val lazyDistance10Feed = homeViewModel.lazyDistance10Feed.collectAsLazyPagingItems()
-    val lazyDistance20Feed = homeViewModel.lazyDistance20Feed.collectAsLazyPagingItems()
-    val lazyDistance50Feed = homeViewModel.lazyDistance50Feed.collectAsLazyPagingItems()
-    Log.e("asd","거리1 값 ${lazyDistance1Feed.itemCount}")
-    Log.e("asd","거리5 값 ${lazyDistance5Feed.itemCount}")
-    Log.e("asd","거리10 값 ${lazyDistance10Feed.itemCount}")
-    Log.e("asd","거리20 값 ${lazyDistance20Feed.itemCount}")
-    Log.e("asd","거리50 값 ${lazyDistance50Feed.itemCount}")
+    // 변경: distance 값에 따라 Flow를 한 번만 생성하도록 캐싱 (재composition 시 재생성 방지)
+    val lazyDistanceFeedFlow = remember(distance) {
+        homeViewModel.getLazyDistanceFeed(distance)
+    }
+    val lazyDistanceFeed = lazyDistanceFeedFlow.collectAsLazyPagingItems()
 
-    // LazyPagingItems 상태 확인
-    Log.e("asd", "거리1 상태 확인 ${lazyDistance1Feed.loadState.refresh}")
-    Log.e("asd", "거리5 상태 확인 ${lazyDistance5Feed.loadState.refresh}")
-    Log.e("asd", "거리10 상태 확인 ${lazyDistance10Feed.loadState.refresh}")
-    Log.e("asd", "거리20 상태 확인 ${lazyDistance20Feed.loadState.refresh}")
-    Log.e("asd", "거리50 상태 확인 ${lazyDistance50Feed.loadState.refresh}")
+//    val lazyDistance1Feed = homeViewModel.lazyDistance1Feed.collectAsLazyPagingItems()
+//    val lazyDistance5Feed = homeViewModel.lazyDistance5Feed.collectAsLazyPagingItems()
+//    val lazyDistance10Feed = homeViewModel.lazyDistance10Feed.collectAsLazyPagingItems()
+//    val lazyDistance20Feed = homeViewModel.lazyDistance20Feed.collectAsLazyPagingItems()
+//    val lazyDistance50Feed = homeViewModel.lazyDistance50Feed.collectAsLazyPagingItems()
 
     val pullRefreshState = rememberPullRefreshState(
         refreshing = isRefreshing,
         onRefresh = {
-            isRefreshing = true
-            when (distance) {
-                DistanceEnum.UNDER_1 -> {
-                    lazyDistance1Feed.refresh()
-                }
-
-                DistanceEnum.UNDER_5 -> {
-                    lazyDistance5Feed.refresh()
-                }
-
-                DistanceEnum.UNDER_10 -> {
-                    lazyDistance10Feed.refresh()
-                }
-
-                DistanceEnum.UNDER_20 -> {
-                    lazyDistance20Feed.refresh()
-                }
-
-                DistanceEnum.UNDER_50 -> {
-                    lazyDistance50Feed.refresh()
-                }
+            // 변경: 이미 로딩중이면 refresh 호출을 방지
+            if (lazyDistanceFeed.loadState.refresh !is LoadState.Loading) {
+                isRefreshing = true
+                lazyDistanceFeed.refresh()
             }
         }
     )
 
-    LaunchedEffect(lazyDistance1Feed) {
-        if (lazyDistance1Feed.loadState.refresh !is LoadState.Loading) {
-            isRefreshing = false
-        }
-    }
+//    val pullRefreshState = rememberPullRefreshState(
+//        refreshing = isRefreshing,
+//        onRefresh = {
+//            isRefreshing = true
+//            when (distance) {
+//                DistanceEnum.UNDER_1 -> {
+//                    lazyDistance1Feed.refresh()
+//                }
+//
+//                DistanceEnum.UNDER_5 -> {
+//                    lazyDistance5Feed.refresh()
+//                }
+//
+//                DistanceEnum.UNDER_10 -> {
+//                    lazyDistance10Feed.refresh()
+//                }
+//
+//                DistanceEnum.UNDER_20 -> {
+//                    lazyDistance20Feed.refresh()
+//                }
+//
+//                DistanceEnum.UNDER_50 -> {
+//                    lazyDistance50Feed.refresh()
+//                }
+//            }
+//        }
+//    )
 
-    LaunchedEffect(lazyDistance5Feed) {
-        if (lazyDistance5Feed.loadState.refresh !is LoadState.Loading) {
-            isRefreshing = false
-        }
+    // 변경: 단일 feed의 상태에 따라 isRefreshing 값을 업데이트 (여기서도 Flow가 새로 생성되지 않도록 주의)
+    LaunchedEffect(lazyDistanceFeed) {
+        snapshotFlow { lazyDistanceFeed.loadState.refresh }
+            .collect { refreshState ->
+                if (refreshState !is LoadState.Loading) {
+                    isRefreshing = false
+                }
+            }
     }
+//    LaunchedEffect(lazyDistance5Feed) {
+//        if (lazyDistance5Feed.loadState.refresh !is LoadState.Loading) {
+//            isRefreshing = false
+//        }
+//    }
+//
+//    LaunchedEffect(lazyDistance10Feed) {
+//        if (lazyDistance10Feed.loadState.refresh !is LoadState.Loading) {
+//            isRefreshing = false
+//        }
+//    }
+//
+//    LaunchedEffect(lazyDistance20Feed) {
+//        if (lazyDistance20Feed.loadState.refresh !is LoadState.Loading) {
+//            isRefreshing = false
+//        }
+//    }
+//
+//    LaunchedEffect(lazyDistance50Feed) {
+//        if (lazyDistance50Feed.loadState.refresh !is LoadState.Loading) {
+//            isRefreshing = false
+//        }
+//    }
 
-    LaunchedEffect(lazyDistance10Feed) {
-        if (lazyDistance10Feed.loadState.refresh !is LoadState.Loading) {
-            isRefreshing = false
-        }
-    }
-
-    LaunchedEffect(lazyDistance20Feed) {
-        if (lazyDistance20Feed.loadState.refresh !is LoadState.Loading) {
-            isRefreshing = false
-        }
-    }
-
-    LaunchedEffect(lazyDistance50Feed) {
-        if (lazyDistance50Feed.loadState.refresh !is LoadState.Loading) {
-            isRefreshing = false
-        }
-    }
+    Log.e("asd","아이템 값:${lazyDistanceFeed.itemCount}")
 
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
-        if ((distance == DistanceEnum.UNDER_1 && lazyDistance1Feed.itemCount == 0) ||
-            (distance == DistanceEnum.UNDER_5 && lazyDistance5Feed.itemCount == 0) ||
-            (distance == DistanceEnum.UNDER_10 && lazyDistance10Feed.itemCount == 0) ||
-            (distance == DistanceEnum.UNDER_20 && lazyDistance20Feed.itemCount == 0) ||
-            (distance == DistanceEnum.UNDER_50 && lazyDistance50Feed.itemCount == 0)
-        ) {
+        if (lazyDistanceFeed.itemCount == 0) {
             ReplaceHomeList()
         } else {
             LazyColumn(
                 state = scrollState,
                 modifier = Modifier.pullRefresh(pullRefreshState)
             ) {
-                when (distance) {
-                    DistanceEnum.UNDER_1 -> {
-                        items(lazyDistance1Feed.itemCount) { index ->
-                            val feedItem = lazyDistance1Feed[index]
-                            feedItem?.let {
-                                DistanceContentCard(it, navController)
-                            }
-                        }
-                    }
-
-                    DistanceEnum.UNDER_5 -> {
-                        items(lazyDistance5Feed.itemCount) { index ->
-                            val feedItem = lazyDistance5Feed[index]
-                            feedItem?.let {
-                                DistanceContentCard(it, navController)
-                            }
-                        }
-                    }
-
-                    DistanceEnum.UNDER_10 -> {
-                        items(lazyDistance10Feed.itemCount) { index ->
-                            val feedItem = lazyDistance10Feed[index]
-                            feedItem?.let {
-                                DistanceContentCard(it, navController)
-                            }
-                        }
-                    }
-
-                    DistanceEnum.UNDER_20 -> {
-                        items(lazyDistance20Feed.itemCount) { index ->
-                            val feedItem = lazyDistance20Feed[index]
-                            feedItem?.let {
-                                DistanceContentCard(it, navController)
-                            }
-                        }
-                    }
-
-                    DistanceEnum.UNDER_50 -> {
-                        items(lazyDistance50Feed.itemCount) { index ->
-                            val feedItem = lazyDistance50Feed[index]
-                            feedItem?.let {
-                                DistanceContentCard(it, navController)
-                            }
-                        }
+                items(lazyDistanceFeed.itemCount) { index ->
+                    val feedItem = lazyDistanceFeed[index]
+                    feedItem?.let {
+                        DistanceContentCard(it, navController)
                     }
                 }
             }
             if (showMoveToTopButton) {
-                Box(modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .padding(bottom = 120.dp)
-                    .clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null
-                    ) {
-                        coroutineScope.launch {
-                            scrollState.animateScrollToItem(0)
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 120.dp)
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null
+                        ) {
+                            coroutineScope.launch {
+                                scrollState.animateScrollToItem(0)
+                            }
                         }
-                    }
                 ) {
                     MoveToTop()
                 }
             }
-            RefreshIndicator(Modifier.align(Alignment.TopCenter), pullRefreshState, isRefreshing)
+            RefreshIndicator(
+                Modifier.align(Alignment.TopCenter),
+                pullRefreshState,
+                isRefreshing
+            )
         }
     }
+
+//    Box(
+//        modifier = Modifier.fillMaxSize(),
+//        contentAlignment = Alignment.Center
+//    ) {
+//        if ((distance == DistanceEnum.UNDER_1 && lazyDistance1Feed.itemCount == 0) ||
+//            (distance == DistanceEnum.UNDER_5 && lazyDistance5Feed.itemCount == 0) ||
+//            (distance == DistanceEnum.UNDER_10 && lazyDistance10Feed.itemCount == 0) ||
+//            (distance == DistanceEnum.UNDER_20 && lazyDistance20Feed.itemCount == 0) ||
+//            (distance == DistanceEnum.UNDER_50 && lazyDistance50Feed.itemCount == 0)
+//        ) {
+//            ReplaceHomeList()
+//        } else {
+//            LazyColumn(
+//                state = scrollState,
+//                modifier = Modifier.pullRefresh(pullRefreshState)
+//            ) {
+//                when (distance) {
+//                    DistanceEnum.UNDER_1 -> {
+//                        items(lazyDistance1Feed.itemCount) { index ->
+//                            val feedItem = lazyDistance1Feed[index]
+//                            feedItem?.let {
+//                                DistanceContentCard(it, navController)
+//                            }
+//                        }
+//                    }
+//
+//                    DistanceEnum.UNDER_5 -> {
+//                        items(lazyDistance5Feed.itemCount) { index ->
+//                            val feedItem = lazyDistance5Feed[index]
+//                            feedItem?.let {
+//                                DistanceContentCard(it, navController)
+//                            }
+//                        }
+//                    }
+//
+//                    DistanceEnum.UNDER_10 -> {
+//                        items(lazyDistance10Feed.itemCount) { index ->
+//                            val feedItem = lazyDistance10Feed[index]
+//                            feedItem?.let {
+//                                DistanceContentCard(it, navController)
+//                            }
+//                        }
+//                    }
+//
+//                    DistanceEnum.UNDER_20 -> {
+//                        items(lazyDistance20Feed.itemCount) { index ->
+//                            val feedItem = lazyDistance20Feed[index]
+//                            feedItem?.let {
+//                                DistanceContentCard(it, navController)
+//                            }
+//                        }
+//                    }
+//
+//                    DistanceEnum.UNDER_50 -> {
+//                        items(lazyDistance50Feed.itemCount) { index ->
+//                            val feedItem = lazyDistance50Feed[index]
+//                            feedItem?.let {
+//                                DistanceContentCard(it, navController)
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//            if (showMoveToTopButton) {
+//                Box(modifier = Modifier
+//                    .align(Alignment.BottomCenter)
+//                    .padding(bottom = 120.dp)
+//                    .clickable(
+//                        interactionSource = remember { MutableInteractionSource() },
+//                        indication = null
+//                    ) {
+//                        coroutineScope.launch {
+//                            scrollState.animateScrollToItem(0)
+//                        }
+//                    }
+//                ) {
+//                    MoveToTop()
+//                }
+//            }
+//            RefreshIndicator(Modifier.align(Alignment.TopCenter), pullRefreshState, isRefreshing)
+//        }
+//    }
 }
 
 @OptIn(ExperimentalMaterialApi::class)

--- a/app/src/main/java/com/sooum/android/ui/HomeScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/HomeScreen.kt
@@ -6,6 +6,8 @@ import android.net.Uri
 import android.os.Build
 import android.provider.Settings
 import android.util.Log
+import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
@@ -106,10 +108,15 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
+import kotlin.system.exitProcess
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun HomeScreen(navController: NavHostController) {
+
+    // 뒤로가기 처리
+    BackPressExitHandler()
+
     var isVisible by remember { mutableStateOf(true) }
 
     val homeViewModel: HomeViewModel = hiltViewModel()
@@ -436,6 +443,7 @@ fun DistanceFeedList(
     distance: DistanceEnum,
 ) {
     val coroutineScope = rememberCoroutineScope()
+    Log.e("asd","거리 값 $distance")
 
     var isRefreshing by remember { mutableStateOf(false) }
 
@@ -444,6 +452,18 @@ fun DistanceFeedList(
     val lazyDistance10Feed = homeViewModel.lazyDistance10Feed.collectAsLazyPagingItems()
     val lazyDistance20Feed = homeViewModel.lazyDistance20Feed.collectAsLazyPagingItems()
     val lazyDistance50Feed = homeViewModel.lazyDistance50Feed.collectAsLazyPagingItems()
+    Log.e("asd","거리1 값 ${lazyDistance1Feed.itemCount}")
+    Log.e("asd","거리5 값 ${lazyDistance5Feed.itemCount}")
+    Log.e("asd","거리10 값 ${lazyDistance10Feed.itemCount}")
+    Log.e("asd","거리20 값 ${lazyDistance20Feed.itemCount}")
+    Log.e("asd","거리50 값 ${lazyDistance50Feed.itemCount}")
+
+    // LazyPagingItems 상태 확인
+    Log.e("asd", "거리1 상태 확인 ${lazyDistance1Feed.loadState.refresh}")
+    Log.e("asd", "거리5 상태 확인 ${lazyDistance5Feed.loadState.refresh}")
+    Log.e("asd", "거리10 상태 확인 ${lazyDistance10Feed.loadState.refresh}")
+    Log.e("asd", "거리20 상태 확인 ${lazyDistance20Feed.loadState.refresh}")
+    Log.e("asd", "거리50 상태 확인 ${lazyDistance50Feed.loadState.refresh}")
 
     val pullRefreshState = rememberPullRefreshState(
         refreshing = isRefreshing,
@@ -707,13 +727,13 @@ fun LatestContentCard(
                     .fillMaxWidth()
                     .height(60.dp)
                     .background(
-                    brush = Brush.verticalGradient(
-                        colors = listOf(
-                            Color(0x00000000), // 투명한 검정
-                            Color(0x99000000)  // 약간 불투명한 검정
+                        brush = Brush.verticalGradient(
+                            colors = listOf(
+                                Color(0x00000000), // 투명한 검정
+                                Color(0x99000000)  // 약간 불투명한 검정
+                            )
                         )
                     )
-                )
                     .align(Alignment.BottomCenter)
             )
             Box(
@@ -796,7 +816,7 @@ fun PopularityContentCard(
                     } else {
                         FontFamily.Default
                     }
-             ,
+                    ,
                     fontWeight = FontWeight.Bold,
                     maxLines = 4,
                     overflow = TextOverflow.Ellipsis,
@@ -1195,10 +1215,21 @@ fun formatTimeDifference(timeString: String): String {
 
 fun formatDistanceInKm(distance: Double): String {
     return when {
-        distance < 0.1 -> "${(distance * 1000).toInt()}m 이내" // 0~99m
-        distance < 1.0 -> "${(distance * 1000).toInt() / 100 * 100}m" // 100~999m
-        distance < 100.0 -> "${distance.toInt()}km" // 1km~100km
-        else -> "${(distance / 100).toInt() * 100}km" // 100km 이상
+        distance == 0.0 -> "100m 이내" // 0일경우
+        distance < 0.1 -> "100m 이내" // 0.1km 미만
+        distance < 1.0 -> {
+            val roundedDistance = ((distance * 1000) / 100).toInt() * 100 // 100m 단위
+            "${roundedDistance}m"
+        }
+        distance < 100.0 -> {
+            // 5km 단위로 반올림
+            val roundedDistance = (Math.round(distance / 5) * 5).toInt()
+            "${roundedDistance}km"
+        }
+        else -> {
+            val roundedDistance = (distance / 100).toInt() * 100 // 100km 단위
+            "${roundedDistance}km"
+        }
     }
 }
 
@@ -1585,6 +1616,29 @@ fun LocationDialog(openLocationDialog: (Boolean) -> Unit, onLocationResulted: (B
                         )
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+fun BackPressExitHandler() {
+    val context = LocalContext.current
+    var backPressedOnce by remember { mutableStateOf(false) }
+
+    val coroutineScope = rememberCoroutineScope()
+
+    // 뒤로가기 버튼 핸들링
+    BackHandler {
+        if (backPressedOnce) {
+            exitProcess(0)
+        } else {
+            backPressedOnce = true
+            Toast.makeText(context, "뒤로 가기 버튼을 한 번 더 누르면 종료됩니다.", Toast.LENGTH_SHORT).show()
+
+            coroutineScope.launch {
+                delay(3000)
+                backPressedOnce = false
             }
         }
     }

--- a/app/src/main/java/com/sooum/android/ui/MainActivity.kt
+++ b/app/src/main/java/com/sooum/android/ui/MainActivity.kt
@@ -4,8 +4,10 @@ import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.location.Location
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Looper
@@ -21,11 +23,19 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -34,6 +44,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -42,7 +53,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -63,12 +77,12 @@ import com.sooum.android.SooumApplication
 import com.sooum.android.User
 import com.sooum.android.ui.common.LogInNav
 import com.sooum.android.ui.common.NotificationNav
-import com.sooum.android.ui.common.PostNav
 import com.sooum.android.ui.common.SooumBottomNavigation
 import com.sooum.android.ui.common.SooumNav
 import com.sooum.android.ui.common.SooumNavHost
 import com.sooum.android.ui.viewmodel.MainViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.system.exitProcess
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -86,6 +100,8 @@ class MainActivity : ComponentActivity() {
                 LocalContext.current.getContentResolver(),
                 Settings.Secure.ANDROID_ID
             )
+
+            mainViewModel.fetchAppVersion(this)
             mainViewModel.login(android_id, {
                 mainViewModel.fetchUnreadNotificationCount()
             })
@@ -177,6 +193,18 @@ fun SplashScreen(
     val permissions =
         arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.POST_NOTIFICATIONS)
 
+    // 앱 버전 다이얼로그
+    AppVersionDialog(mainViewModel.showDialogVersion) { updateValue ->
+        if(updateValue) {
+            // 업데이트 진행할 시
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=${context.packageName}"))
+            context.startActivity(intent)
+        }else {
+            // 업데이트 진행 안할 시
+            exitProcess(0)
+        }
+    }
+
     LaunchedEffect(Unit) {
         // 서버 호출 (예시로 delay로 가정)
 //        mainViewModel.login(android_id, context, {
@@ -209,16 +237,21 @@ fun SplashScreen(
                     User.userInfo.latitude = location.latitude
                     User.userInfo.longitude = location.longitude
                 }
+                if (!mainViewModel.showDialogVersion.value) {
+                    navController.navigate("main") {
+                        popUpTo(navController.graph.id) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                }
+
+            }
+        } else {
+            Log.d("123", "권한 거부됨")
+            if (!mainViewModel.showDialogVersion.value) {
                 navController.navigate("main") {
                     popUpTo(navController.graph.id) { inclusive = true }
                     launchSingleTop = true
                 }
-            }
-        } else {
-            Log.d("123", "권한 거부됨")
-            navController.navigate("main") {
-                popUpTo(navController.graph.id) { inclusive = true }
-                launchSingleTop = true
             }
         }
     }
@@ -261,9 +294,11 @@ fun SplashScreen(
                     User.userInfo.latitude = location.latitude
                     User.userInfo.longitude = location.longitude
                 }
-                navController.navigate("main") {
-                    popUpTo(navController.graph.id) { inclusive = true }
-                    launchSingleTop = true
+                if (!mainViewModel.showDialogVersion.value) {
+                    navController.navigate("main") {
+                        popUpTo(navController.graph.id) { inclusive = true }
+                        launchSingleTop = true
+                    }
                 }
             }
         }
@@ -458,6 +493,87 @@ fun Main(mainViewModel: MainViewModel) {
                     startDestination = LogInNav.LogIn.screenRoute,
                     mainViewModel
                 )
+            }
+        }
+    }
+}
+
+@Composable
+fun AppVersionDialog(
+    showDialogState: MutableState<Boolean>,
+    onButtonClick: (Boolean) -> Unit,
+) {
+    if (showDialogState.value) {
+        Dialog(onDismissRequest = {
+
+        }) {
+            Card(
+                shape = RoundedCornerShape(20.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(
+                        top = 22.dp,
+                        bottom = 14.dp,
+                        start = 14.dp,
+                        end = 14.dp
+                    ),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    androidx.compose.material3.Text(
+                        text = "업데이트 안내",
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = colorResource(R.color.gray800),
+                        lineHeight = 24.sp
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    androidx.compose.material3.Text(
+                        text = "안정적인 서비스를 사용을 위해\n최신버전으로 업데이트해주세요.",
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Medium,
+                        color = colorResource(R.color.gray600),
+                        lineHeight = 19.6.sp
+                    )
+                    Spacer(modifier = Modifier.height(20.dp))
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Button(
+                            onClick = {
+                                onButtonClick(false)
+                            },
+                            modifier = Modifier
+                                .width(130.dp)
+                                .height(46.dp),
+                            colors = ButtonDefaults.buttonColors(containerColor = colorResource(R.color.gray03)),
+                            shape = RoundedCornerShape(10.dp)
+                        ) {
+                            androidx.compose.material3.Text(
+                                text = "종료하기",
+                                fontSize = 16.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = Color.Black.copy(alpha = 0.5f)
+                            )
+                        }
+                        Button(
+                            onClick = {
+                                onButtonClick(true)
+                            },
+                            modifier = Modifier
+                                .width(130.dp)
+                                .height(46.dp),
+                            colors = ButtonDefaults.buttonColors(containerColor = colorResource(R.color.primary_color)),
+                            shape = RoundedCornerShape(10.dp)
+                        ) {
+                            androidx.compose.material3.Text(
+                                text = "업데이트",
+                                fontSize = 16.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = Color.White
+                            )
+                        }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/sooum/android/ui/NotificationScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/NotificationScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
@@ -96,7 +95,7 @@ fun NotificationScreen(navController: NavController) {
                     }
             )
             Text(
-                text = "덧글 히스토리",
+                text = "알림",
                 fontSize = 16.sp,
                 fontWeight = FontWeight.SemiBold,
                 lineHeight = 24.sp,
@@ -135,20 +134,17 @@ fun TabLayout(
         ) {
             tabList.forEachIndexed { index, page ->
                 val selected = (pagerState.currentPage == index)
-                Tab(
-                    selected = selected,
-                    onClick = {
-                        coroutineScope.launch { pagerState.animateScrollToPage(index) }
-                    },
+                Box(
                     modifier = Modifier
                         .padding(top = 7.dp, bottom = 11.dp)
                         .clickable(
                             onClick = {
                                 coroutineScope.launch { pagerState.animateScrollToPage(index) }
                             },
-                            indication = null, // 리플 효과 제거
+                            indication = null,
                             interactionSource = remember { MutableInteractionSource() }
-                        )
+                        ),
+                    contentAlignment = Alignment.Center
                 ) {
                     Text(
                         text = when (page) {
@@ -164,6 +160,37 @@ fun TabLayout(
                         lineHeight = 19.6.sp
                     )
                 }
+                // 기존 코드 백업용
+//                Tab(
+//                    selected = selected,
+//                    onClick = {
+//                        coroutineScope.launch { pagerState.animateScrollToPage(index) }
+//                    },
+//                    modifier = Modifier
+//                        .padding(top = 7.dp, bottom = 11.dp)
+//                        .clickable(
+//                            onClick = {
+//                                coroutineScope.launch { pagerState.animateScrollToPage(index) }
+//                            },
+//                            indication = null, // 리플 효과 제거
+//                            interactionSource = remember { MutableInteractionSource() },
+//
+//                            ),
+//                ) {
+//                    Text(
+//                        text = when (page) {
+//                            TabEnum.ALL -> "전체"
+//                            TabEnum.REPLY -> "답카드"
+//                            TabEnum.LIKE -> "공감"
+//                        },
+//                        color = if (selected) colorResource(R.color.blue300)
+//                        else colorResource(R.color.gray400),
+//                        fontSize = 14.sp,
+//                        fontWeight = if (selected) FontWeight.Medium
+//                        else FontWeight.Normal,
+//                        lineHeight = 19.6.sp
+//                    )
+//                }
             }
         }
         HorizontalPager(
@@ -185,7 +212,6 @@ fun TabLayout(
         }
     }
 }
-
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable

--- a/app/src/main/java/com/sooum/android/ui/TagListScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/TagListScreen.kt
@@ -1,7 +1,6 @@
 package com.sooum.android.ui
 
 import android.os.Build
-import android.widget.Space
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -50,11 +49,8 @@ import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.paging.LoadState
-import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
-import androidx.paging.compose.itemKey
 import com.sooum.android.R
-import com.sooum.android.User
 import com.sooum.android.domain.model.TagFeedDataModel
 import com.sooum.android.ui.common.PostNav
 import com.sooum.android.ui.viewmodel.TagViewModel
@@ -216,6 +212,11 @@ fun TagListScreen(navController: NavController, tagId: String) {
                     LazyColumn(
                         state = tagScrollState,
                         modifier = Modifier.pullRefresh(pullRefreshState)
+                            .align(if(lazyTagFeed.itemCount == 1) {
+                                Alignment.TopStart
+                            }else {
+                                Alignment.Center
+                            })
                     ) {
                         items(lazyTagFeed.itemCount) { index ->
                             TagContentCard(lazyTagFeed[index]!!, index, onItemClick = { cardId ->

--- a/app/src/main/java/com/sooum/android/ui/common/SooumBottomNavigation.kt
+++ b/app/src/main/java/com/sooum/android/ui/common/SooumBottomNavigation.kt
@@ -49,7 +49,7 @@ fun SooumBottomNavigation(navController: NavHostController) {
                 )
                 clip = true
             }
-            .height(70.dp), containerColor = White70
+            .height(75.dp), containerColor = White70
     ) {
 
         val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -63,8 +63,9 @@ fun SooumBottomNavigation(navController: NavHostController) {
                     Text(
                         text = stringResource(id = screen.title),
                         fontWeight = FontWeight.Bold,
-                        fontSize = 10.sp,
-                        modifier = Modifier.padding(top = 4.dp)
+                        fontSize = 11.sp,
+                        modifier = Modifier
+                            .padding(top = 5.dp)
                     )
                 },
                 selected = isSelected,
@@ -88,7 +89,9 @@ fun SooumBottomNavigation(navController: NavHostController) {
                     Icon(
                         painter = painterResource(id = screen.icon),
                         contentDescription = screen.screenRoute,
-                        modifier = Modifier.size(18.dp)
+                        modifier = Modifier
+                            .size(27.dp)
+                            .padding(bottom = 4.dp)
                     )
                 },
                 modifier = Modifier

--- a/app/src/main/java/com/sooum/android/ui/myprofile/MyCommentHistoryScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/myprofile/MyCommentHistoryScreen.kt
@@ -10,6 +10,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -26,14 +29,21 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.sooum.android.R
 import com.sooum.android.ui.ImageLoaderForUrl
+import com.sooum.android.ui.RefreshIndicator
 import com.sooum.android.ui.common.PostNav
 import com.sooum.android.ui.viewmodel.MyCommentHistoryViewModel
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun MyCommentHistoryScreen(navController: NavHostController) {
 
     val viewModel: MyCommentHistoryViewModel = hiltViewModel()
 
+    // PullRefreshState를 관리
+    val pullRefreshState = rememberPullRefreshState(refreshing = viewModel.refreshing.value, onRefresh = {
+        // 새로 고침 시작
+        viewModel.refreshComments()
+    })
 
     Box(
         modifier = Modifier
@@ -42,6 +52,7 @@ fun MyCommentHistoryScreen(navController: NavHostController) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .pullRefresh(pullRefreshState)
         ) {
             Box(
                 modifier = Modifier
@@ -54,13 +65,16 @@ fun MyCommentHistoryScreen(navController: NavHostController) {
                     tint = colorResource(R.color.gray_black),
                     modifier = Modifier
                         .align(Alignment.CenterStart)
-                        .clickable {
+                        .clickable(
+                            interactionSource = null,
+                            indication = null,
+                        ) {
                             navController.popBackStack()
                         }
                         .padding(15.dp)
                 )
                 Text(
-                    text = "덧글 히스토리",
+                    text = "답카드 히스토리",
                     fontWeight = FontWeight.Bold,
                     fontSize = 16.sp,
                     lineHeight = 24.sp,
@@ -69,7 +83,14 @@ fun MyCommentHistoryScreen(navController: NavHostController) {
                         .padding(15.dp)
                 )
 
+                // 새로 고침 인디케이터
+                RefreshIndicator(
+                    state = pullRefreshState,
+                    refreshing = viewModel.refreshing.value,
+                    modifier = Modifier.align(Alignment.Center)
+                )
             }
+
             LazyVerticalGrid(
                 columns = GridCells.Fixed(3)
             ) {

--- a/app/src/main/java/com/sooum/android/ui/myprofile/SettingScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/myprofile/SettingScreen.kt
@@ -41,7 +41,7 @@ import com.sooum.android.ui.viewmodel.SettingViewModel
 fun SettingScreen(navController: NavHostController) {
     val context = LocalContext.current
     val settingViewModel : SettingViewModel = hiltViewModel()
-   // var isChecked by remember { mutableStateOf(settingViewModel.isNotify.value) }
+    // var isChecked by remember { mutableStateOf(settingViewModel.isNotify.value) }
 
     Box(
         modifier = Modifier
@@ -113,7 +113,7 @@ fun SettingScreen(navController: NavHostController) {
                         .align(Alignment.CenterEnd)
                 )
             }
-            SettingRow("작성된 덧글 히스토리") {
+            SettingRow("작성된 답카드 히스토리") {
                 navController.navigate(MyProfile.MyCommentHistory.screenRoute)
             }
 

--- a/app/src/main/java/com/sooum/android/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/sooum/android/ui/viewmodel/HomeViewModel.kt
@@ -30,7 +30,7 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     getLatestFeedUseCase: LatestFeedUseCase,
     private val getPopularityFeedUseCase: PopularityFeedUseCase,
-    getDistanceFeedUseCase: DistanceFeedUseCase
+    private val getDistanceFeedUseCase: DistanceFeedUseCase
 ): ViewModel() {
 
     val lazyLatestFeed = getLatestFeedUseCase(User.userInfo.latitude, User.userInfo.longitude).cachedIn(viewModelScope)
@@ -38,20 +38,38 @@ class HomeViewModel @Inject constructor(
     var popularityCardList = mutableStateListOf<SortedByPopularityDataModel.Embedded.PopularFeedCard>()
         private set
 
-    val lazyDistance1Feed = if (User.userInfo.latitude != null && User.userInfo.longitude != null) getDistanceFeedUseCase(User.userInfo.latitude!!, User.userInfo.longitude!!, DistanceEnum.UNDER_1).cachedIn(viewModelScope)
-    else emptyFlow<PagingData<SortedByDistanceDataModel.Embedded.DistanceFeedCard>>().cachedIn(viewModelScope)
+//    val lazyDistance1Feed = if (User.userInfo.latitude != null && User.userInfo.longitude != null) getDistanceFeedUseCase(User.userInfo.latitude!!, User.userInfo.longitude!!, DistanceEnum.UNDER_1).cachedIn(viewModelScope)
+//    else emptyFlow<PagingData<SortedByDistanceDataModel.Embedded.DistanceFeedCard>>().cachedIn(viewModelScope)
+//
+//    val lazyDistance5Feed = if (User.userInfo.latitude != null && User.userInfo.longitude != null) getDistanceFeedUseCase(User.userInfo.latitude!!, User.userInfo.longitude!!, DistanceEnum.UNDER_5).cachedIn(viewModelScope)
+//    else emptyFlow<PagingData<SortedByDistanceDataModel.Embedded.DistanceFeedCard>>().cachedIn(viewModelScope)
+//
+//    val lazyDistance10Feed = if (User.userInfo.latitude != null && User.userInfo.longitude != null) getDistanceFeedUseCase(User.userInfo.latitude!!, User.userInfo.longitude!!, DistanceEnum.UNDER_10).cachedIn(viewModelScope)
+//    else emptyFlow<PagingData<SortedByDistanceDataModel.Embedded.DistanceFeedCard>>().cachedIn(viewModelScope)
+//
+//    val lazyDistance20Feed = if (User.userInfo.latitude != null && User.userInfo.longitude != null) getDistanceFeedUseCase(User.userInfo.latitude!!, User.userInfo.longitude!!, DistanceEnum.UNDER_20).cachedIn(viewModelScope)
+//    else emptyFlow<PagingData<SortedByDistanceDataModel.Embedded.DistanceFeedCard>>().cachedIn(viewModelScope)
+//
+//    val lazyDistance50Feed = if (User.userInfo.latitude != null && User.userInfo.longitude != null) getDistanceFeedUseCase(User.userInfo.latitude!!, User.userInfo.longitude!!, DistanceEnum.UNDER_50).cachedIn(viewModelScope)
+//    else emptyFlow<PagingData<SortedByDistanceDataModel.Embedded.DistanceFeedCard>>().cachedIn(viewModelScope)
 
-    val lazyDistance5Feed = if (User.userInfo.latitude != null && User.userInfo.longitude != null) getDistanceFeedUseCase(User.userInfo.latitude!!, User.userInfo.longitude!!, DistanceEnum.UNDER_5).cachedIn(viewModelScope)
-    else emptyFlow<PagingData<SortedByDistanceDataModel.Embedded.DistanceFeedCard>>().cachedIn(viewModelScope)
 
-    val lazyDistance10Feed = if (User.userInfo.latitude != null && User.userInfo.longitude != null) getDistanceFeedUseCase(User.userInfo.latitude!!, User.userInfo.longitude!!, DistanceEnum.UNDER_10).cachedIn(viewModelScope)
-    else emptyFlow<PagingData<SortedByDistanceDataModel.Embedded.DistanceFeedCard>>().cachedIn(viewModelScope)
 
-    val lazyDistance20Feed = if (User.userInfo.latitude != null && User.userInfo.longitude != null) getDistanceFeedUseCase(User.userInfo.latitude!!, User.userInfo.longitude!!, DistanceEnum.UNDER_20).cachedIn(viewModelScope)
-    else emptyFlow<PagingData<SortedByDistanceDataModel.Embedded.DistanceFeedCard>>().cachedIn(viewModelScope)
+    // 기존에 5개의 LazyFlow를 미리 생성하던 방식을 제거하고,
+    // 선택된 거리(distance)에 따라 해당 Flow를 반환하는 함수로 변경함.
+    fun getLazyDistanceFeed(distance: DistanceEnum): Flow<PagingData<SortedByDistanceDataModel.Embedded.DistanceFeedCard>> {
+        return if (User.userInfo.latitude != null && User.userInfo.longitude != null) {
+            getDistanceFeedUseCase(
+                User.userInfo.latitude!!,
+                User.userInfo.longitude!!,
+                distance
+            ).cachedIn(viewModelScope)
+        } else {
+            emptyFlow<PagingData<SortedByDistanceDataModel.Embedded.DistanceFeedCard>>()
+                .cachedIn(viewModelScope)
+        }
+    }
 
-    val lazyDistance50Feed = if (User.userInfo.latitude != null && User.userInfo.longitude != null) getDistanceFeedUseCase(User.userInfo.latitude!!, User.userInfo.longitude!!, DistanceEnum.UNDER_50).cachedIn(viewModelScope)
-    else emptyFlow<PagingData<SortedByDistanceDataModel.Embedded.DistanceFeedCard>>().cachedIn(viewModelScope)
 
     fun fetchPopularityCardList(latitude: Double?, longitude: Double?, onFetchFinished: () -> Unit) {
         viewModelScope.launch {

--- a/app/src/main/java/com/sooum/android/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/sooum/android/ui/viewmodel/MainViewModel.kt
@@ -1,5 +1,6 @@
 package com.sooum.android.ui.viewmodel
 
+import android.content.Context
 import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
@@ -17,6 +18,7 @@ import com.sooum.android.domain.model.Token
 import com.sooum.android.domain.usecase.notification.AllUnreadCountUseCase
 import com.sooum.android.domain.usecase.notification.ReadNotificationUseCase
 import com.sooum.android.domain.usecase.profile.SuspensionUseCase
+import com.sooum.android.domain.usecase.version.AppVersionUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import java.security.KeyFactory
@@ -31,7 +33,8 @@ import javax.inject.Inject
 class MainViewModel @Inject constructor(
     private val getAllUnreadCountUseCase: AllUnreadCountUseCase,
     private val readNotificationUseCase: ReadNotificationUseCase,
-    private val suspensionUseCase: SuspensionUseCase
+    private val suspensionUseCase: SuspensionUseCase,
+    private val getAppVersionUseCase: AppVersionUseCase
 ) : ViewModel() {
     val retrofitInstance = SooumApplication().instance.create(CardApi::class.java)
     var key by mutableStateOf<String?>(null)
@@ -43,6 +46,9 @@ class MainViewModel @Inject constructor(
 
     var unreadNotificationCount = mutableStateOf(0)
         private set
+
+    // 버전 비교용 다이얼로그
+    val showDialogVersion = mutableStateOf(false)
 
     @RequiresApi(Build.VERSION_CODES.O)
     fun base64ToRSAPublicKey(base64Key: String): PublicKey {
@@ -151,6 +157,29 @@ class MainViewModel @Inject constructor(
             } catch (e: Exception) {
                 Log.e("HomeViewModel", e.printStackTrace().toString())
             }
+        }
+    }
+
+    fun fetchAppVersion(context: Context) {
+        viewModelScope.launch {
+            runCatching {
+                getAppVersionUseCase()
+            }
+                .onSuccess { version ->
+                    val packageManager = context.packageManager
+                    val packageName = context.packageName
+                    val packageInfo = packageManager.getPackageInfo(packageName, 0)
+
+                    if (version.isNotEmpty()) {
+                        // api 에러 방지
+                        if (version != packageInfo.versionName) {
+                            showDialogVersion.value = true
+                        }
+                    }
+                }
+                .onFailure { error ->
+                    Log.e("error ", "error : ${error.message}")
+                }
         }
     }
 }

--- a/app/src/main/java/com/sooum/android/ui/viewmodel/MyCommentHistoryViewModel.kt
+++ b/app/src/main/java/com/sooum/android/ui/viewmodel/MyCommentHistoryViewModel.kt
@@ -11,18 +11,40 @@ import javax.inject.Inject
 @HiltViewModel
 class MyCommentHistoryViewModel @Inject constructor(
     private val myCommentUseCase: MyCommentUseCase,
-) :
-    ViewModel() {
+) : ViewModel() {
+
+    // 댓글 데이터 상태
     var myCommentCard = mutableStateOf<List<MyCommentCardDataModel.MyCommentCardDto>>(emptyList())
         private set
 
+    // 새로 고침 상태 관리
+    var refreshing = mutableStateOf(false)
+        private set
+
     init {
+        // 초기 댓글 데이터 가져오기
         getMyCommentCard()
     }
 
+    // 댓글 데이터 새로고침
     fun getMyCommentCard() {
         viewModelScope.launch {
-            myCommentCard.value = myCommentUseCase()
+            // 새로 고침 시작
+            refreshing.value = true
+            // runCatching을 사용하여 예외를 처리
+            runCatching {
+                // 데이터 가져오기
+                myCommentCard.value = myCommentUseCase()
+            }.onFailure {
+                // 예외 처리
+            }.onSuccess {
+                refreshing.value = false
+            }
         }
+    }
+
+    // 새로 고침 함수
+    fun refreshComments() {
+        getMyCommentCard()
     }
 }


### PR DESCRIPTION
알림 창 상단 툴바 타이틀 덧글히스토리 -> 알림 수정
알림창 탭 클릭시 리플효과 제거
태그 피드 글 하나일 시 맨위로 붙어있게 수정
피드에서 뒤로가기 두번 연속 클릭 시 앱 종료되게 수정
바텀바 아이콘 크기 18 -> 27 수정
바텀바 라벨 크기 10 -> 11 수정
바텀바 높이 70 -> 75 수정
설정창 "작성된 덧글히스토리" -> "작성된 답카드 히스토리 수정"
답카드 히스토리 뒤로가기버튼 리플효과 제거
답카드 히스토리 새로고침 기능 추가
홈화면 거리 단위 수정 
스플래쉬 화면에서 앱 업데이트 검사 실행(업데이트 클릭 시 마켓 주소로 이동)
홈화면에서 다른 거리 필터 선택시 정상적으로 리스트 나오게 수정
버전 조회시 scalars 없어도 가능하게 수정