### PR TITLE
[Fix]:  Fix Bug

### DIFF
--- a/app/src/main/java/com/sooum/android/data/paging/DistanceFeedPagingSource.kt
+++ b/app/src/main/java/com/sooum/android/data/paging/DistanceFeedPagingSource.kt
@@ -1,10 +1,13 @@
 package com.sooum.android.data.paging
 
+import android.util.Log
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.sooum.android.data.remote.CardApi
 import com.sooum.android.domain.model.SortedByDistanceDataModel
 import com.sooum.android.enums.DistanceEnum
+import kotlinx.coroutines.delay
+import retrofit2.HttpException
 
 class DistanceFeedPagingSource(
     private val apiService: CardApi,
@@ -14,43 +17,62 @@ class DistanceFeedPagingSource(
 ) : PagingSource<Long, SortedByDistanceDataModel.Embedded.DistanceFeedCard>() {
 
     override suspend fun load(params: LoadParams<Long>): LoadResult<Long, SortedByDistanceDataModel.Embedded.DistanceFeedCard> {
-        return try {
-            val lastCardId = params.key
-            val response = if (lastCardId == null) {
-                // 초기 요청
-                apiService.getDistanceCardList(latitude, longitude, distanceEnum)
-            } else {
-                // 추가 요청
-                apiService.getDistanceCardListAfter(lastCardId, latitude, longitude, distanceEnum)
-            }
+        val maxRetries = 3
+        var currentRetry = 0
 
-            if (response.isSuccessful) {
-                if (response.code() == 204) {
-                    return LoadResult.Page(
-                        data = emptyList(),
-                        prevKey = null,
-                        nextKey = null
-                    )
+        while (true) {
+            try {
+                val lastCardId = params.key
+                val response = if (lastCardId == null) {
+                    // 초기 요청
+                    apiService.getDistanceCardList(latitude, longitude, distanceEnum)
+                } else {
+                    // 추가 요청
+                    apiService.getDistanceCardListAfter(lastCardId, latitude, longitude, distanceEnum)
                 }
 
-                val body = response.body() ?: return LoadResult.Error(Exception("Empty response body"))
-                val cards = body.embedded.distanceCardDtoList
+                if (response.isSuccessful) {
+                    if (response.code() == 204) {
+                        return LoadResult.Page(
+                            data = emptyList(),
+                            prevKey = null,
+                            nextKey = null
+                        )
+                    }
 
-                LoadResult.Page(
-                    data = cards,
-                    prevKey = null,
-                    nextKey = cards.lastOrNull()?.id
-                )
-            } else {
-                LoadResult.Error(Exception("API Error: ${response.code()}"))
+                    val body = response.body() ?: return LoadResult.Error(Exception("Empty response body"))
+                    val cards = body.embedded.distanceCardDtoList
+
+                    return LoadResult.Page(
+                        data = cards,
+                        prevKey = null,
+                        nextKey = cards.lastOrNull()?.id
+                    )
+                } else {
+                    // 429 에러인 경우 재시도 처리
+                    if (response.code() == 429 && currentRetry < maxRetries) {
+                        currentRetry++
+                        Log.e("DistanceFeedPagingSource", "429 Too Many Requests, retry attempt: $currentRetry")
+                        delay(500L * currentRetry) // 지수 백오프 적용
+                        continue
+                    }
+                    return LoadResult.Error(Exception("API Error: ${response.code()}"))
+                }
+            } catch (e: Exception) {
+                // 예외가 HttpException이고 429 에러인 경우 재시도 처리
+                if (e is HttpException && e.code() == 429 && currentRetry < maxRetries) {
+                    currentRetry++
+                    Log.e("DistanceFeedPagingSource", "Exception 429 Too Many Requests, retry attempt: $currentRetry")
+                    delay(500L * currentRetry)
+                    continue
+                }
+                return LoadResult.Error(e)
             }
-        } catch (e: Exception) {
-            LoadResult.Error(e)
         }
     }
 
     override fun getRefreshKey(state: PagingState<Long, SortedByDistanceDataModel.Embedded.DistanceFeedCard>): Long? {
-        // refresh() 시 항상 초기 요청을 보장
+        // refresh 시 항상 초기 요청을 보장
         return null
     }
 }

--- a/app/src/main/java/com/sooum/android/ui/AddPostScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/AddPostScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedTextFieldDefaults
@@ -162,7 +163,6 @@ fun AddPostScreen(
     var selectedImage by remember { mutableStateOf(0) }
 
     var selectedImageForGallery by remember { mutableStateOf<Bitmap?>(null) }
-
 
 
     //태그 텍스트 필드
@@ -296,7 +296,7 @@ fun AddPostScreen(
         sheetContent = {
             Column(
                 modifier = Modifier
-                    .padding(start = 20.dp, end = 20.dp, bottom = 20.dp)
+                    .padding(bottom = 20.dp)
             ) {
                 Spacer(modifier = Modifier.height(8.dp))
                 Surface(
@@ -308,7 +308,9 @@ fun AddPostScreen(
                     color = colorResource(R.color.gray400)
                 ) { }
                 Spacer(modifier = Modifier.height(20.dp))
-                Row {
+                Row(
+                    Modifier.padding(start = 20.dp, end = 20.dp)
+                ) {
                     androidx.compose.material3.Text(
                         text = "기본이미지",
                         fontSize = 16.sp,
@@ -402,7 +404,9 @@ fun AddPostScreen(
                 Spacer(modifier = Modifier.height(16.dp))
                 if (imgType == ImgTypeEnum.DEFAULT) {
                     Surface(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 20.dp, end = 20.dp),
                         shape = RoundedCornerShape(10.dp)
                     ) {
                         LazyVerticalGrid(
@@ -420,7 +424,7 @@ fun AddPostScreen(
                                             } else if (imageIndex == 7) {
                                                 RoundedCornerShape(bottomEnd = 10.dp)
                                             } else {
-                                                RoundedCornerShape(0.dp,)
+                                                RoundedCornerShape(0.dp)
                                             }
                                         } else {
                                             RoundedCornerShape(0.dp)
@@ -453,7 +457,7 @@ fun AddPostScreen(
                             }
                         )
 
-                        }
+                    }
 
                 } else {
                     Box(
@@ -461,6 +465,7 @@ fun AddPostScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .aspectRatio(2f)
+                            .padding(start = 20.dp, end = 20.dp)
                     ) {
                         Card(
                             modifier = Modifier
@@ -508,12 +513,15 @@ fun AddPostScreen(
                     text = "글씨체",
                     fontSize = 16.sp,
                     fontWeight = FontWeight.Medium,
-                    color = colorResource(R.color.gray700)
+                    color = colorResource(R.color.gray700),
+                    modifier = Modifier.padding(start = 20.dp, end = 20.dp)
                 )
                 Spacer(modifier = Modifier.height(12.dp))
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 20.dp, end = 20.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
                     Surface(
                         color = if (fontType == FontEnum.PRETENDARD) {
@@ -580,10 +588,16 @@ fun AddPostScreen(
                         }
                     }
                 }
-                Spacer(modifier = Modifier.height(48.dp))
+                Spacer(modifier = Modifier.height(15.dp))
+                Divider(
+                    modifier = Modifier.height(5.dp),
+                    color = Color(android.graphics.Color.parseColor("#E5E5E5"))
+                )
+                Spacer(modifier = Modifier.height(15.dp))
                 if (cardId == null) {
                     Row(
-                        verticalAlignment = Alignment.CenterVertically
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(start = 20.dp, end = 20.dp)
                     ) {
                         Column {
                             androidx.compose.material3.Text(
@@ -626,7 +640,8 @@ fun AddPostScreen(
                     Spacer(modifier = Modifier.height(20.dp))
                 }
                 Row(
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(start = 20.dp, end = 20.dp)
                 ) {
                     Column {
                         androidx.compose.material3.Text(
@@ -669,7 +684,8 @@ fun AddPostScreen(
                 if (cardId == null) {
                     Spacer(modifier = Modifier.height(14.dp))
                     Row(
-                        verticalAlignment = Alignment.CenterVertically
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(start = 20.dp, end = 20.dp)
                     ) {
                         androidx.compose.material3.Text(
                             text = "나만보기",

--- a/app/src/main/java/com/sooum/android/ui/AddPostScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/AddPostScreen.kt
@@ -1221,7 +1221,7 @@ fun TagHintChip(tagHint: String, count: Int, onTagClick: (String) -> Unit) {
                     modifier = Modifier.padding(start = 2.dp),
                     text = if (count < 10) "0$count" else "$count",
                     color = Primary,
-                    fontWeight = FontWeight.Medium
+                    //fontWeight = FontWeight.Medium
                 )
             }
         }

--- a/app/src/main/java/com/sooum/android/ui/DetailScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/DetailScreen.kt
@@ -909,8 +909,12 @@ fun DeatilCommentItem(
             )
             Box(
                 modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(end = 26.dp, bottom = 24.dp)
+                    // 기존 코드
+//                    .align(Alignment.BottomEnd)
+//                    .padding(end = 26.dp, bottom = 24.dp)
+                    // 중앙 정렬 코드
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 24.dp)
             ) {
                 Row(
                     modifier = Modifier,

--- a/app/src/main/java/com/sooum/android/ui/DetailScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/DetailScreen.kt
@@ -605,7 +605,7 @@ fun DetailScreen(
 
                                     Text(
                                         text = data.member.nickname,
-                                        fontSize = 10.sp,
+                                        fontSize = 13.sp,
                                         color = Color.White,
                                         fontWeight = FontWeight(600),
                                         modifier = Modifier

--- a/app/src/main/java/com/sooum/android/ui/DetailScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/DetailScreen.kt
@@ -912,9 +912,11 @@ fun DeatilCommentItem(
                     // 기존 코드
 //                    .align(Alignment.BottomEnd)
 //                    .padding(end = 26.dp, bottom = 24.dp)
+                    //.padding(bottom = 24.dp)
+
                     // 중앙 정렬 코드
                     .align(Alignment.BottomCenter)
-                    .padding(bottom = 24.dp)
+                    .padding(bottom = 14.dp)
             ) {
                 Row(
                     modifier = Modifier,

--- a/app/src/main/java/com/sooum/android/ui/DetailScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/DetailScreen.kt
@@ -960,12 +960,12 @@ fun TagItem(item: Tag, onClick: (String) -> Unit) {
                 onClick(item.id)
             },
         shape = RoundedCornerShape(4.dp),
-        color = Gray3
+        color =  Color(android.graphics.Color.parseColor("#E5E5E5"))
     ) {
         Text(
             text = "#${item.content}",
             fontSize = 14.sp,
-            color = Gray1,
+            color = Gray500,
             modifier = Modifier
                 .padding(start = 20.dp, end = 20.dp, top = 4.dp, bottom = 4.dp)
         )

--- a/app/src/main/java/com/sooum/android/ui/HomeScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/HomeScreen.kt
@@ -1181,7 +1181,7 @@ fun CreatedTimeElement(createdTime: String) {
         Spacer(modifier = Modifier.width(4.dp))
         Text(
             text = formatTimeDifference(createdTime),
-            fontSize = 12.sp,
+            fontSize = 13.sp,
             fontWeight = FontWeight.Normal,
             lineHeight = 16.8.sp,
             color = colorResource(R.color.gray_white)
@@ -1205,7 +1205,7 @@ fun DistanceElement(distance: Double) {
         Spacer(modifier = Modifier.width(4.dp))
         Text(
             text = formatDistanceInKm(distance),
-            fontSize = 12.sp,
+            fontSize = 13.sp,
             fontWeight = FontWeight.Normal,
             lineHeight = 16.8.sp,
             color = colorResource(R.color.gray_white)
@@ -1237,7 +1237,7 @@ fun LikeElement(isLiked: Boolean, likeCount: Int) {
         Spacer(modifier = Modifier.width(4.dp))
         Text(
             text = likeCount.toString(),
-            fontSize = 12.sp,
+            fontSize = 13.sp,
             fontWeight = FontWeight.Normal,
             lineHeight = 16.8.sp,
             color = if (isLiked) {
@@ -1273,7 +1273,7 @@ fun CommentElement(isCommentWritten: Boolean, commentCount: Int) {
         Spacer(modifier = Modifier.width(4.dp))
         Text(
             text = commentCount.toString(),
-            fontSize = 12.sp,
+            fontSize = 13.sp,
             fontWeight = FontWeight.Normal,
             lineHeight = 16.8.sp,
             color = if (isCommentWritten) {

--- a/app/src/main/java/com/sooum/android/ui/HomeScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/HomeScreen.kt
@@ -1362,7 +1362,7 @@ fun InfoElement(painter: Painter, description: String, count: String, isTrue: Bo
         Spacer(modifier = Modifier.width(2.dp))
         Text(
             text = count,
-            fontSize = 10.sp,
+            fontSize = 13.sp,
             fontWeight = FontWeight(600),
             lineHeight = 12.sp,
             color = Color.White

--- a/app/src/main/java/com/sooum/android/ui/common/SooumBottomNavigation.kt
+++ b/app/src/main/java/com/sooum/android/ui/common/SooumBottomNavigation.kt
@@ -65,7 +65,6 @@ fun SooumBottomNavigation(navController: NavHostController) {
                         fontWeight = FontWeight.Bold,
                         fontSize = 11.sp,
                         modifier = Modifier
-                            .padding(top = 5.dp)
                     )
                 },
                 selected = isSelected,
@@ -91,7 +90,7 @@ fun SooumBottomNavigation(navController: NavHostController) {
                         contentDescription = screen.screenRoute,
                         modifier = Modifier
                             .size(27.dp)
-                            .padding(bottom = 4.dp)
+                            .padding(bottom = 6.dp)
                     )
                 },
                 modifier = Modifier

--- a/app/src/main/java/com/sooum/android/ui/myprofile/MyProfileScreen.kt
+++ b/app/src/main/java/com/sooum/android/ui/myprofile/MyProfileScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -188,7 +189,8 @@ fun MyProfileScreen(navController: NavHostController) {
                                 Spacer(modifier = Modifier.height(4.dp))
                                 Text(
                                     text = "카드",
-                                    fontSize = 10.sp,
+                                    fontSize = 11.sp,
+                                    fontFamily = FontFamily.Default,
                                     lineHeight = 14.sp,
                                     fontWeight = FontWeight.Medium,
                                     color = colorResource(R.color.gray500)
@@ -212,7 +214,8 @@ fun MyProfileScreen(navController: NavHostController) {
                                 Spacer(modifier = Modifier.height(4.dp))
                                 Text(
                                     text = "팔로잉",
-                                    fontSize = 10.sp,
+                                    fontSize = 11.sp,
+                                    fontFamily = FontFamily.Default,
                                     lineHeight = 14.sp,
                                     fontWeight = FontWeight.Medium,
                                     color = colorResource(R.color.gray500)
@@ -236,7 +239,8 @@ fun MyProfileScreen(navController: NavHostController) {
                                 Spacer(modifier = Modifier.height(4.dp))
                                 Text(
                                     text = "팔로워",
-                                    fontSize = 10.sp,
+                                    fontSize = 11.sp,
+                                    fontFamily = FontFamily.Default,
                                     lineHeight = 14.sp,
                                     fontWeight = FontWeight.Medium,
                                     color = colorResource(R.color.gray500)


### PR DESCRIPTION
[Fix]: 거리 피드 pagingSource 429 Error 대응 코드 추가
[Fix]: 관련 태그 숫자 FontWeight 제거 
[Fix]: DetailScreen 태그 색상 수정 
[Fix]: 바텀 네비게이션 아이콘과 텍스트 간격 2dp 추가 
[Fix]: 프로필 상단 텍스트 1sp 크게 적용 및 폰트 적용 
[Fix]: 답카드의 정보 중앙 정렬 적용 
[Fix]: 답카드의 정보 중앙 정렬 적용 (padding 값 수정) 
[Fix]: 글쓰기 바텀시트 modifier 조절 divider 추가 
[Fix]: DetailScreen 프로필 텍스트 사이즈 10 -> 13 
[Fix]: HomeScreen 프로필 텍스트 사이즈 12 -> 13 